### PR TITLE
Allow a square cropping mask too.

### DIFF
--- a/RSKImageCropper/RSKImageCropViewController.h
+++ b/RSKImageCropper/RSKImageCropViewController.h
@@ -55,6 +55,15 @@
  */
 @property (strong, nonatomic) UIImage *originalImage;
 
+///--------------------------
+/// @name Customizing the Crop Mask
+///--------------------------
+
+/**
+ Specify whether cropping mask should be square, instead of circular. Defaults to NO.
+ */
+@property (assign, nonatomic) BOOL shouldUseSquareCroppingMask;
+
 @end
 
 /**

--- a/RSKImageCropper/RSKImageCropViewController.m
+++ b/RSKImageCropper/RSKImageCropViewController.m
@@ -67,6 +67,7 @@ static const CGFloat kLandscapeCancelAndChooseButtonsVerticalMargin = 12.0f;
     self = [super init];
     if (self) {
         _originalImage = originalImage;
+        _shouldUseSquareCroppingMask = NO;
     }
     return self;
 }
@@ -342,6 +343,9 @@ static const CGFloat kLandscapeCancelAndChooseButtonsVerticalMargin = 12.0f;
 {
     UIBezierPath *clipPath = [UIBezierPath bezierPathWithRect:self.overlayView.frame];
     UIBezierPath *maskPath = [UIBezierPath bezierPathWithOvalInRect:[self maskRect]];
+    if (_shouldUseSquareCroppingMask) {
+        maskPath = [UIBezierPath bezierPathWithRect:[self maskRect]];
+    }
     
     [clipPath appendPath:maskPath];
     clipPath.usesEvenOddFillRule = YES;


### PR DESCRIPTION
Excellent work on this image cropper.  I added this pull request because I wanted the option to use a square cropping mask.  Your image cropper is the best I've come across so far because it supports landscape and portrait modes.

I just added a boolean property to specify that a square mask should be used.  The default is NO, so the circle remains the standard.

Great job!
