### PR TITLE
Report cropRect to delegate

### DIFF
--- a/RSKImageCropper/RSKImageCropViewController.h
+++ b/RSKImageCropper/RSKImageCropViewController.h
@@ -205,4 +205,9 @@ typedef NS_ENUM(NSUInteger, RSKImageCropMode) {
  */
 - (void)imageCropViewController:(RSKImageCropViewController *)controller willCropImage:(UIImage *)originalImage;
 
+/**
+ Tells the delegate that the original image has been cropped. Additionally provides a crop rect used to produce image.
+ */
+- (void)imageCropViewController:(RSKImageCropViewController *)controller didCropImage:(UIImage *)croppedImage usingCropRect:(CGRect)cropRect;
+
 @end

--- a/RSKImageCropper/RSKImageCropViewController.m
+++ b/RSKImageCropper/RSKImageCropViewController.m
@@ -600,7 +600,8 @@ static const CGFloat kLandscapeCancelAndChooseButtonsVerticalMargin = 12.0f;
         [self.delegate imageCropViewController:self willCropImage:self.originalImage];
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        UIImage *croppedImage = [self croppedImage:self.originalImage cropRect:[self cropRect]];
+        CGRect cropRect = [self cropRect];
+        UIImage *croppedImage = [self croppedImage:self.originalImage cropRect:cropRect];
         dispatch_async(dispatch_get_main_queue(), ^{
             if ([self.delegate respondsToSelector:@selector(imageCropViewController:didCropImage:usingCropRect:)]) {
                 [self.delegate imageCropViewController:self didCropImage:croppedImage usingCropRect:cropRect];

--- a/RSKImageCropper/RSKImageCropViewController.m
+++ b/RSKImageCropper/RSKImageCropViewController.m
@@ -602,7 +602,9 @@ static const CGFloat kLandscapeCancelAndChooseButtonsVerticalMargin = 12.0f;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         UIImage *croppedImage = [self croppedImage:self.originalImage cropRect:[self cropRect]];
         dispatch_async(dispatch_get_main_queue(), ^{
-            if ([self.delegate respondsToSelector:@selector(imageCropViewController:didCropImage:)]) {
+            if ([self.delegate respondsToSelector:@selector(imageCropViewController:didCropImage:usingCropRect:)]) {
+                [self.delegate imageCropViewController:self didCropImage:croppedImage usingCropRect:cropRect];
+            } else if ([self.delegate respondsToSelector:@selector(imageCropViewController:didCropImage:)]) {
                 [self.delegate imageCropViewController:self didCropImage:croppedImage];
             }
         });


### PR DESCRIPTION
Hi,

I need to know a crop rect. I put together a PR but I encountered couple of unexpected things that you could probably help me to tackle.

1.) cropRect has floats which is bad because of sub pixel rendering. I guess rounding coordinates or using `CGRectIntegral` wouldn't hurt.

```
Printing description of cropRect:
(CGRect) cropRect = origin=(x=0, y=183.887268) size=(width=3264, height=1838.87329)
Printing description of croppedImage:
<UIImage: 0x14dc9220> size {1840, 3264} orientation 0 scale 1.000000
```

It seems that `CGImageCreateWithImageInRect` uses ceil() and then rounds it to next even.

2.) `cropRect` method returns flipped coordinates. Would be great if `cropRect` matched the orientation of cropped image and `croppedImage:cropRect:` did all the magic. In that case we could pass cropRect directly to delegate.

