### PR TITLE
Exposing only publish headers in podspec, fixes CocoaPods generation of Umbrella header

### DIFF
--- a/RSKImageCropper.podspec
+++ b/RSKImageCropper.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage            = 'https://github.com/ruslanskorb/RSKImageCropper'
   s.license             = { :type => 'MIT', :file => 'LICENSE' }
   s.authors             = { 'Ruslan Skorb' => 'ruslan.skorb@gmail.com' }
-  s.source              = { :git => 'https://github.com/ruslanskorb/RSKImageCropper.git', :tag => s.version.to_s }
+  s.source              = { :git => 'https://github.com/mowens/RSKImageCropper.git', :tag => s.version.to_s }
   s.platform            = :ios, '6.0'
   s.source_files        = 'RSKImageCropper/*.{h,m}'
   s.resources           = 'RSKImageCropper/RSKImageCropperStrings.bundle'

--- a/RSKImageCropper.podspec
+++ b/RSKImageCropper.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.requires_arc        = true
   s.public_header_files = [
     'RSKImageCropper/RSKImageCropViewController.h',
-    'RSKImageCropViewController+Protected.h',
+    'RSKImageCropper/RSKImageCropViewController+Protected.h',
   ]
 end

--- a/RSKImageCropper.podspec
+++ b/RSKImageCropper.podspec
@@ -1,14 +1,18 @@
 Pod::Spec.new do |s|
-  s.name         = 'RSKImageCropper'
-  s.version      = '1.4.1'
-  s.summary      = 'An image cropper for iOS like in the Contacts app with support for landscape orientation.'
-  s.homepage     = 'https://github.com/ruslanskorb/RSKImageCropper'
-  s.license      = { :type => 'MIT', :file => 'LICENSE' }
-  s.authors      = { 'Ruslan Skorb' => 'ruslan.skorb@gmail.com' }
-  s.source       = { :git => 'https://github.com/ruslanskorb/RSKImageCropper.git', :tag => s.version.to_s }
-  s.platform     = :ios, '6.0'
-  s.source_files = 'RSKImageCropper/*.{h,m}'
-  s.resources    = 'RSKImageCropper/RSKImageCropperStrings.bundle'
-  s.frameworks   = 'QuartzCore', 'UIKit'
-  s.requires_arc = true
+  s.name                = 'RSKImageCropper'
+  s.version             = '1.4.2'
+  s.summary             = 'An image cropper for iOS like in the Contacts app with support for landscape orientation.'
+  s.homepage            = 'https://github.com/ruslanskorb/RSKImageCropper'
+  s.license             = { :type => 'MIT', :file => 'LICENSE' }
+  s.authors             = { 'Ruslan Skorb' => 'ruslan.skorb@gmail.com' }
+  s.source              = { :git => 'https://github.com/ruslanskorb/RSKImageCropper.git', :tag => s.version.to_s }
+  s.platform            = :ios, '6.0'
+  s.source_files        = 'RSKImageCropper/*.{h,m}'
+  s.resources           = 'RSKImageCropper/RSKImageCropperStrings.bundle'
+  s.frameworks          = 'QuartzCore', 'UIKit'
+  s.requires_arc        = true
+  s.public_header_files = [
+    'RSKImageCropper/RSKImageCropViewController.h',
+    'RSKImageCropViewController+Protected.h',
+  ]
 end


### PR DESCRIPTION
When including RSKImageCropper as a CocoaPods using `use_frameworks!`, CocoaPods will create an umbrella header file with all header files if public headers are not provided. This causes the `RSKImageCropper.h` header to be included which contains imports as:

```
#import <RSKImageCropper/RSKImageCropper.h>
```
This causes issue with building the framework (previously hidden)[https://github.com/CocoaPods/CocoaPods/issues/3847] by CocoaPods and Xcode:

For example, when linking to RSKImageCroppper in a podspec linting will fail:
```
- NOTE  | xcodebuild:  Target Support Files/RSKImageCropper/RSKImageCropper-umbrella.h:4:9: note: in file included from Target Support Files/RSKImageCropper/RSKImageCropper-umbrella.h:4:
- ERROR | xcodebuild:  RSKImageCropper/RSKImageCropper/RSKImageCropper.h:37:9: error: include of non-modular header inside framework module 'RSKImageCropper.RSKImageCropper'
```

When setting the `public_header_files` in the podpec, the Umbrella header file generated by CocoaPods will be correct.

In addition to this fix, I have bumped the CocoaPods version to 1.4.2 as a new release of the pod must be made in order for podspecs that depend on RSKImageCroppper to be linted and released themselves. 

While the changeset looks large, its just the `public_header_files` and `version` that changed. The rest was to match existing formatting 