### PR TITLE
onChooseButtonTouch disenable the button to avoid clilking twice

### DIFF
--- a/RSKImageCropper/RSKImageCropViewController.m
+++ b/RSKImageCropper/RSKImageCropViewController.m
@@ -521,6 +521,7 @@ static const CGFloat kLayoutImageScrollViewAnimationDuration = 0.25;
 
 - (void)onChooseButtonTouch:(UIBarButtonItem *)sender
 {
+    [sender setEnabled:NO];
     [self cropImage];
 }
 


### PR DESCRIPTION
Thanks for your awesome work! This little change maybe better for other library to use. Wish you like to merge. This is for purpose of solving issues in our project when using third-party library [ivpusic/react-native-image-crop-picker](https://github.com/ivpusic/react-native-image-crop-picker/pull/161)