### PR TITLE
Remove modulemap

### DIFF
--- a/RSKImageCropper.podspec
+++ b/RSKImageCropper.podspec
@@ -7,7 +7,6 @@ Pod::Spec.new do |s|
   s.authors       = { 'Ruslan Skorb' => 'ruslan.skorb@gmail.com' }
   s.source        = { :git => 'https://github.com/ruslanskorb/RSKImageCropper.git', :tag => s.version.to_s }
   s.platform      = :ios, '6.0'
-  s.module_map    = 'RSKImageCropper/module.modulemap'
   s.source_files  = 'RSKImageCropper/*.{h,m}'
   s.resources     = 'RSKImageCropper/RSKImageCropperStrings.bundle'
   s.frameworks    = 'QuartzCore', 'UIKit'

--- a/RSKImageCropper/module.modulemap
+++ b/RSKImageCropper/module.modulemap
@@ -1,6 +1,0 @@
-framework module RSKImageCropper {
-    umbrella header "RSKImageCropper.h"
-
-    export *
-    module * { export * }
-}


### PR DESCRIPTION
Using Cocoapods and the Xcode 8.3 beta (tested on beta 2 and 3), there is a compiler error "Redefinition of module RSKImageCropper". Looking at the module map, it's not significantly different from the one Cocoapods generates, and I couldn't see where it would be used for Carthage. I've run `carthage build --no-skip-current` and everything seemed to compile successfully and I have pointed my Podfile at my fork and it has indeed fixed the compile error.