### PR TITLE
update module map

### DIFF
--- a/RSKImageCropper.podspec
+++ b/RSKImageCropper.podspec
@@ -7,7 +7,6 @@ Pod::Spec.new do |s|
   s.authors       = { 'Ruslan Skorb' => 'ruslan.skorb@gmail.com' }
   s.source        = { :git => 'https://github.com/ruslanskorb/RSKImageCropper.git', :tag => s.version.to_s }
   s.platform      = :ios, '6.0'
-  s.module_map    = 'RSKImageCropper/module.modulemap'
   s.source_files  = 'RSKImageCropper/*.{h,m}'
   s.resources     = 'RSKImageCropper/RSKImageCropperStrings.bundle'
   s.frameworks    = 'QuartzCore', 'UIKit'


### PR DESCRIPTION
Removed unnecessary modulemap from the podspec.
With the old podspec file, when we compile in xcode8.3 beta3, it will complaint module redefinition 