### PR TITLE
Fix Xcode 8.3 issue: Redefinition of module

### DIFF
--- a/RSKImageCropper.podspec
+++ b/RSKImageCropper.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.authors       = { 'Ruslan Skorb' => 'ruslan.skorb@gmail.com' }
   s.source        = { :git => 'https://github.com/ruslanskorb/RSKImageCropper.git', :tag => s.version.to_s }
   s.platform      = :ios, '6.0'
-  s.module_map    = 'RSKImageCropper/RSKImageCropper.modulemap'
   s.source_files  = 'RSKImageCropper/*.{h,m}'
+  s.public_header_files = 'RSKImageCropper/*.h'
   s.resources     = 'RSKImageCropper/RSKImageCropperStrings.bundle'
   s.frameworks    = 'QuartzCore', 'UIKit'
   s.requires_arc  = true


### PR DESCRIPTION
Not sure why, but only for your Pod we have problem in Xcode 8.3 in our project:
![](https://monosnap.com/file/G1KRfUvw14YxTXL5A4piJIbc4TYIs2.png)

I think it is because of custom modulemap file. If I change settings in podspec to default cocoapods umbrella-header and modulemap - problem disappears, our project builds good.

Do you have any other reason to use custom modulemap file?