### PR TITLE
Added functionality for zoom to rect

### DIFF
--- a/Example/RSKImageCropperExampleTests/RSKImageCropViewControllerTests.m
+++ b/Example/RSKImageCropperExampleTests/RSKImageCropViewControllerTests.m
@@ -87,6 +87,7 @@
 - (void)imageCropViewController:(RSKImageCropViewController *)controller willCropImage:(UIImage *)originalImage {}
 - (void)imageCropViewController:(RSKImageCropViewController *)controller didCropImage:(UIImage *)croppedImage usingCropRect:(CGRect)cropRect rotationAngle:(CGFloat)rotationAngle {};
 - (void)imageCropViewControllerDidCancelCrop:(RSKImageCropViewController *)controller {};
+- (void)imageCropViewControllerDidDisplayImage:(RSKImageCropViewController *)controller {};
 
 @end
 
@@ -703,6 +704,21 @@ describe(@"delegate", ^{
         [[delegateMock expect] imageCropViewControllerDidCancelCrop:imageCropViewController];
         
         [imageCropViewController cancelCrop];
+        
+        [delegateMock verify];
+        [delegateMock stopMocking];
+    });
+    
+    it(@"calls the appropriate delegate method when the image is displayed", ^{
+        RSKImageCropViewControllerDelegateObject1 *delegateObject = [[RSKImageCropViewControllerDelegateObject1 alloc] init];
+        imageCropViewController.delegate = delegateObject;
+        imageCropViewController.originalImage = originalImage;
+        
+        id delegateMock = [OCMockObject partialMockForObject:delegateObject];
+        
+        [[delegateMock expect] imageCropViewControllerDidDisplayImage:imageCropViewController];
+        
+        [imageCropViewController displayImage];
         
         [delegateMock verify];
         [delegateMock stopMocking];

--- a/Example/RSKImageCropperExampleTests/RSKImageCropViewControllerTests.m
+++ b/Example/RSKImageCropperExampleTests/RSKImageCropViewControllerTests.m
@@ -1034,6 +1034,26 @@ describe(@"taps", ^{
     });
 });
 
+describe(@"zoomToRect", ^{
+    before(^{
+        imageCropViewController = [[RSKImageCropViewController alloc] initWithImage:originalImage];
+        sharedLoadView();
+    });
+    
+    it(@"zooms the image", ^{
+        float initialScale = imageCropViewController.imageScrollView.zoomScale;
+        [imageCropViewController zoomToRect:CGRectMake(0, 0, 1, 1) animated:NO];
+        float afterZoomScale = imageCropViewController.imageScrollView.zoomScale;
+        
+        expect(initialScale).to.beLessThan(1);
+        expect(afterZoomScale).to.beGreaterThanOrEqualTo(1);
+    });
+    
+    after(^{
+        imageCropViewController = nil;
+    });
+});
+
 afterAll(^{
     originalImage = nil;
     imageCropViewController = nil;

--- a/Example/RSKImageCropperExampleTests/RSKImageCropViewControllerTests.m
+++ b/Example/RSKImageCropperExampleTests/RSKImageCropViewControllerTests.m
@@ -1040,13 +1040,18 @@ describe(@"zoomToRect", ^{
         sharedLoadView();
     });
     
-    it(@"zooms the image", ^{
-        float initialScale = imageCropViewController.imageScrollView.zoomScale;
-        [imageCropViewController zoomToRect:CGRectMake(0, 0, 1, 1) animated:NO];
-        float afterZoomScale = imageCropViewController.imageScrollView.zoomScale;
+    it(@"zooms to a specific area of the image", ^{
+        CGRect rect = CGRectMake(100.0, 100.0, 400.0, 400.0);
+        [imageCropViewController zoomToRect:rect animated:NO];
         
-        expect(initialScale).to.beLessThan(1);
-        expect(afterZoomScale).to.beGreaterThanOrEqualTo(1);
+        UIScrollView *imageScrollView = imageCropViewController.imageScrollView;
+        CGRect visibleRect = CGRectMake(round(imageScrollView.contentOffset.x / imageScrollView.zoomScale),
+                                        round(imageScrollView.contentOffset.y / imageScrollView.zoomScale),
+                                        imageScrollView.bounds.size.width / imageScrollView.zoomScale,
+                                        imageScrollView.bounds.size.height / imageScrollView.zoomScale);
+        
+        BOOL contains = CGRectContainsRect(visibleRect, rect);
+        expect(contains).to.beTruthy();
     });
     
     after(^{

--- a/RSKImageCropper/RSKImageCropViewController.h
+++ b/RSKImageCropper/RSKImageCropViewController.h
@@ -55,6 +55,14 @@ typedef NS_ENUM(NSUInteger, RSKImageCropMode) {
  */
 - (instancetype)initWithImage:(UIImage *)originalImage cropMode:(RSKImageCropMode)cropMode;
 
+/**
+ Zoom the image to make sure a specific region is displayed.
+ 
+ @param zoomRect The rect to center in the view.
+ @param animated If the zoom should be animated.
+ */
+- (void)zoomToRect:(CGRect)zoomRect animated:(BOOL)animated;
+
 ///-----------------------------
 /// @name Accessing the Delegate
 ///-----------------------------
@@ -316,6 +324,11 @@ typedef NS_ENUM(NSUInteger, RSKImageCropMode) {
  The `RSKImageCropViewControllerDelegate` protocol defines messages sent to a image crop view controller delegate when crop image was canceled or the original image was cropped.
  */
 @protocol RSKImageCropViewControllerDelegate <NSObject>
+
+/**
+ Tells the delegate that the image has been displayed.
+ */
+- (void)imageCropViewControllerDisplayedImage:(RSKImageCropViewController *)controller;
 
 /**
  Tells the delegate that crop image has been canceled.

--- a/RSKImageCropper/RSKImageCropViewController.h
+++ b/RSKImageCropper/RSKImageCropViewController.h
@@ -56,12 +56,12 @@ typedef NS_ENUM(NSUInteger, RSKImageCropMode) {
 - (instancetype)initWithImage:(UIImage *)originalImage cropMode:(RSKImageCropMode)cropMode;
 
 /**
- Zoom the image to make sure a specific region is displayed.
+ Zooms to a specific area of the image so that it is visible.
  
- @param zoomRect The rect to center in the view.
- @param animated If the zoom should be animated.
+ @param zoomRect A rectangle defining an area of the image.
+ @param animated YES if the scrolling should be animated, NO if it should be immediate.
  */
-- (void)zoomToRect:(CGRect)zoomRect animated:(BOOL)animated;
+- (void)zoomToRect:(CGRect)rect animated:(BOOL)animated;
 
 ///-----------------------------
 /// @name Accessing the Delegate
@@ -326,11 +326,6 @@ typedef NS_ENUM(NSUInteger, RSKImageCropMode) {
 @protocol RSKImageCropViewControllerDelegate <NSObject>
 
 /**
- Tells the delegate that the image has been displayed.
- */
-- (void)imageCropViewControllerDisplayedImage:(RSKImageCropViewController *)controller;
-
-/**
  Tells the delegate that crop image has been canceled.
  */
 - (void)imageCropViewControllerDidCancelCrop:(RSKImageCropViewController *)controller;
@@ -341,6 +336,11 @@ typedef NS_ENUM(NSUInteger, RSKImageCropMode) {
 - (void)imageCropViewController:(RSKImageCropViewController *)controller didCropImage:(UIImage *)croppedImage usingCropRect:(CGRect)cropRect rotationAngle:(CGFloat)rotationAngle;
 
 @optional
+
+/**
+ Tells the delegate that the image has been displayed.
+ */
+- (void)imageCropViewControllerDidDisplayImage:(RSKImageCropViewController *)controller;
 
 /**
  Tells the delegate that the original image will be cropped.

--- a/RSKImageCropper/RSKImageCropViewController.h
+++ b/RSKImageCropper/RSKImageCropViewController.h
@@ -58,7 +58,7 @@ typedef NS_ENUM(NSUInteger, RSKImageCropMode) {
 /**
  Zooms to a specific area of the image so that it is visible.
  
- @param zoomRect A rectangle defining an area of the image.
+ @param rect A rectangle defining an area of the image.
  @param animated YES if the scrolling should be animated, NO if it should be immediate.
  */
 - (void)zoomToRect:(CGRect)rect animated:(BOOL)animated;

--- a/RSKImageCropper/RSKImageCropViewController.m
+++ b/RSKImageCropper/RSKImageCropViewController.m
@@ -584,9 +584,9 @@ static const CGFloat kLayoutImageScrollViewAnimationDuration = 0.25;
     }
 }
 
-- (void)zoomToRect:(CGRect)zoomRect animated:(BOOL)animated
+- (void)zoomToRect:(CGRect)rect animated:(BOOL)animated
 {
-    [self.imageScrollView zoomToRect:zoomRect animated:animated];
+    [self.imageScrollView zoomToRect:rect animated:animated];
 }
 
 #pragma mark - Public
@@ -700,8 +700,8 @@ static const CGFloat kLayoutImageScrollViewAnimationDuration = 0.25;
         [self.imageScrollView displayImage:self.originalImage];
         [self reset:NO];
 
-        if ([self.delegate respondsToSelector:@selector(imageCropViewControllerDisplayedImage:)]) {
-            [self.delegate imageCropViewControllerDisplayedImage:self];
+        if ([self.delegate respondsToSelector:@selector(imageCropViewControllerDidDisplayImage:)]) {
+            [self.delegate imageCropViewControllerDidDisplayImage:self];
         }
 
     }

--- a/RSKImageCropper/RSKImageCropViewController.m
+++ b/RSKImageCropper/RSKImageCropViewController.m
@@ -584,6 +584,11 @@ static const CGFloat kLayoutImageScrollViewAnimationDuration = 0.25;
     }
 }
 
+- (void)zoomToRect:(CGRect)zoomRect animated:(BOOL)animated
+{
+    [self.imageScrollView zoomToRect:zoomRect animated:animated];
+}
+
 #pragma mark - Public
 
 - (BOOL)isPortraitInterfaceOrientation
@@ -694,6 +699,11 @@ static const CGFloat kLayoutImageScrollViewAnimationDuration = 0.25;
     if (self.originalImage) {
         [self.imageScrollView displayImage:self.originalImage];
         [self reset:NO];
+
+        if ([self.delegate respondsToSelector:@selector(imageCropViewControllerDisplayedImage:)]) {
+            [self.delegate imageCropViewControllerDisplayedImage:self];
+        }
+
     }
 }
 

--- a/RSKImageCropper/RSKImageCropViewController.m
+++ b/RSKImageCropper/RSKImageCropViewController.m
@@ -703,7 +703,6 @@ static const CGFloat kLayoutImageScrollViewAnimationDuration = 0.25;
         if ([self.delegate respondsToSelector:@selector(imageCropViewControllerDidDisplayImage:)]) {
             [self.delegate imageCropViewControllerDidDisplayImage:self];
         }
-
     }
 }
 


### PR DESCRIPTION
This is the changes I needed in order to solve #194. The functionality can be seen in action here:

https://www.dropbox.com/s/emckb1c57qsqsno/IMG_2849.MOV?dl=0

The top button works as it always has. The bottom button uses face-detection to find the rect of the first face, and then use the functionality of this PR to zoom to that location.